### PR TITLE
add functionality for tower fire rates

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -361,9 +361,9 @@ function App() {
 		}
 	}, []);
 
-	const fireTowers = useCallback((towerTypes: String[]) => {
-		towerTypes.forEach((type) => {
-			towerDefenseState.towers.filter((tower) => tower.type === type).forEach((tower) => {
+	const fireTowers = useCallback((towerTypes: string[]) => {
+		towerDefenseState.towers.forEach((tower) => {
+			if (towerTypes.includes(tower.type)) {
 				// only hit first enemy
 				for (let i = 0; i < towerDefenseState.units.length; i++) {
 					const unit = towerDefenseState.units[i];
@@ -392,9 +392,8 @@ function App() {
 						}
 					}
 				}
-			});
+			}
 		});
-		
 	}, [towerDefenseState]);
 
 	const handleTowerDefenseEvents = useCallback(

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -361,37 +361,40 @@ function App() {
 		}
 	}, []);
 
-	const fireTowers = useCallback(() => {
-		towerDefenseState.towers.forEach((tower) => {
-			// only hit first enemy
-			for (let i = 0; i < towerDefenseState.units.length; i++) {
-				const unit = towerDefenseState.units[i];
-
-				const { ref } = unit;
-				if (ref && ref.current) {
-					const rect = ref.current.getBoundingClientRect();
-
-					const distance = getDistanceBetweenPoints(
-						tower.left,
-						tower.top,
-						rect.left,
-						rect.top
-					);
-
-					const relativeDistance = distance / window.innerWidth;
-
-					if (relativeDistance < 0.4) {
-						socket.emit('event', {
-							key: 'tower defense',
-							value: 'fire tower',
-							towerKey: tower.key,
-							unitKey: unit.key
-						});
-						break;
+	const fireTowers = useCallback((towerTypes: String[]) => {
+		towerTypes.forEach((type) => {
+			towerDefenseState.towers.filter((tower) => tower.type === type).forEach((tower) => {
+				// only hit first enemy
+				for (let i = 0; i < towerDefenseState.units.length; i++) {
+					const unit = towerDefenseState.units[i];
+	
+					const { ref } = unit;
+					if (ref && ref.current) {
+						const rect = ref.current.getBoundingClientRect();
+	
+						const distance = getDistanceBetweenPoints(
+							tower.left,
+							tower.top,
+							rect.left,
+							rect.top
+						);
+	
+						const relativeDistance = distance / window.innerWidth;
+	
+						if (relativeDistance < 0.4) {
+							socket.emit('event', {
+								key: 'tower defense',
+								value: 'fire tower',
+								towerKey: tower.key,
+								unitKey: unit.key
+							});
+							break;
+						}
 					}
 				}
-			}
+			});
 		});
+		
 	}, [towerDefenseState]);
 
 	const handleTowerDefenseEvents = useCallback(
@@ -444,7 +447,7 @@ function App() {
 			}
 
 			if (message.value === 'fire towers') {
-				fireTowers();
+				fireTowers(message.towerTypes);
 			}
 
 			if (message.value === 'hit unit') {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -512,7 +512,7 @@ const spawnEnemy = (roomId: string) => {
   });
 };
 
-const fireTowers = (roomId: string, towerTypes: String[]) => {
+const fireTowers = (roomId: string, towerTypes: string[]) => {
   io.to(roomId).emit("event", { key: "tower defense", value: "fire towers", towerTypes: towerTypes });
 };
 
@@ -543,7 +543,7 @@ const startGame = (roomId: string) => {
       spawnEnemy(roomId);
     }
 
-    let towerTypes: String[] = []
+    let towerTypes: string[] = []
 
     // fire every 4 seconds
     if (loopCounter % 4 === 0) {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -512,8 +512,8 @@ const spawnEnemy = (roomId: string) => {
   });
 };
 
-const fireTowers = (roomId: string) => {
-  io.to(roomId).emit("event", { key: "tower defense", value: "fire towers" });
+const fireTowers = (roomId: string, towerTypes: String[]) => {
+  io.to(roomId).emit("event", { key: "tower defense", value: "fire towers", towerTypes: towerTypes });
 };
 
 const GAME_LENGTH_SECONDS = 120;
@@ -543,10 +543,19 @@ const startGame = (roomId: string) => {
       spawnEnemy(roomId);
     }
 
+    let towerTypes: String[] = []
+
     // fire every 4 seconds
     if (loopCounter % 4 === 0) {
-      fireTowers(roomId);
+      towerTypes.push('basic')
     }
+
+    // fire every 3 seconds
+    if (loopCounter % 3 === 0) {
+      towerTypes.push('bowman')
+    }
+
+    if (towerTypes.length > 0) fireTowers(roomId, towerTypes)
 
     towerDefenseStateRoom.loopCounter++;
 


### PR DESCRIPTION
hacky solution to get towers firing at different rates

can take it further & move some decisioning logic out of the `towerDefenseStateRoom` loop. basically centralize & convenience functionality